### PR TITLE
Añadir README.md y mejorar configuración de Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Programación III - Ejercicios y Exámenes
+
+Este repositorio contiene una colección de ejercicios y exámenes resueltos de la asignatura Programación III.
+
+## Estructura del Proyecto
+
+El proyecto está organizado de la siguiente manera:
+
+- `enunciados/`: Contiene los enunciados de los ejercicios y exámenes en formato PDF e imagen.
+- `src/`: Directorio que contiene el código fuente en Java.
+    - `src/examenenes/`: Soluciones a diversos exámenes organizadas por fecha (ordinarias, extraordinarias y parciales).
+    - `src/recursividad/`: Ejercicios de práctica sobre recursividad.
+- `pom.xml`: Archivo de configuración de Maven para la gestión de dependencias y construcción del proyecto.
+
+## Requisitos
+
+- Java 8 o superior.
+- Maven.
+
+## Cómo ejecutar las pruebas
+
+Para ejecutar las pruebas unitarias del proyecto, utiliza el siguiente comando de Maven:
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
   <version>0.0.1-SNAPSHOT</version>
   <build>
     <sourceDirectory>src</sourceDirectory>
+    <testSourceDirectory>src</testSourceDirectory>
     <resources>
       <resource>
         <directory>src</directory>
@@ -29,7 +30,6 @@
   		<groupId>junit</groupId>
   		<artifactId>junit</artifactId>
   		<version>4.12</version>
-  		<scope>test</scope>
   	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Se ha añadido un archivo README.md detallado en español que explica el propósito del repositorio (ejercicios y exámenes de Programación III). Además, se han realizado ajustes técnicos en el archivo pom.xml para que el proyecto sea compatible con los comandos estándar de Maven (como 'mvn test'), ya que la estructura de carpetas original no seguía el estándar habitual de Maven.

---
*PR created automatically by Jules for task [15218626528396000090](https://jules.google.com/task/15218626528396000090) started by @igoraresti*